### PR TITLE
feat: Double trigger sends `off` command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,11 @@ set(PROJECT_NAME "remoteSimulator")
 
 set(CMAKE_CXX_STANDARD 11)
 
-set(SWITCH_FAMILY "a" CACHE STRING  "Zibase(c) signal family" )
-set(SWITCH_GROUP  1   CACHE INTEGER "Zibase(c) signal group"  )
-set(SWITCH_NUMBER 1   CACHE INTEGER "Zibase(c) signal number" )
-
+set(SWITCH_FAMILY "a"                 CACHE STRING  "Zibase(c) signal family"   )
+set(SWITCH_GROUP 1                    CACHE INTEGER "Zibase(c) signal group"    )
+set(SWITCH_NUMBER 1                   CACHE INTEGER "Zibase(c) signal number"   )
+set(LOW_BATTERY_VOLTAGE 4400          CACHE INTEGER "Low battery voltage in mV" )
+set(USE_DOUBLE_TRIGGER_FOR_OFF FALSE  CACHE BOOL    "Use double trigger for 'off' signal")
 
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON ) 
 if( EXISTS "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" )

--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
 # Remote Simulator
 
 [![Travis build](https://travis-ci.org/arcadien/remoteSimulator.svg?branch=master)](https://travis-ci.org/arcadien/remoteSimulator)
-[![codecov](https://codecov.io/gh/arcadien/remoteSimulator/branch/master/graph/badge.svg)](https://codecov.io/gh/arcadien/remoteSimulator)
 
-This firmware allow to trigger the emission of a 433Mhz signal when an event
-occurs. The send signal is a on/off signal, so that this firmware is not
-suitable for temperature or other discrete data. It is suited for sound,
-light or movment detection. The trigger sensor can be active low or high.
-Two different definitions and two pins are used to select one mode or another.
-The firmware also monitors the power level, so that a low battery level will
-make the LED signal to quickly blink each 8 seconds.
-mode.
+This firmware allow to trigger the emission of a 433Mhz signal when a 'trigger event' occurs. 
+The sent signal is a on/off signal, so that this firmware is not suitable for temperature or other discrete data. 
+It is suited for something like sound, light or motion detection. 
+The trigger sensor can be active low or high (ie my motion sensor is active high where my sound detector is active low). 
+Two different build options and two pins are used to select one mode or another.
+The firmware also monitors the power level, so that a low battery level will make the LED to quickly blink each 8 seconds.
+
 
 Technical details:
 - Written for ATTiny85
 - Uses CMake or PlatformIO for build
-- The AVR watchdog is used for deep sleep management.
-- Battery level is evaluated comparing Vcc with internal 1V1 reference
+- The AVR watchdog is used for deep sleep management
+- Battery level is evaluated comparing Vcc with internal 1V1 reference, and low battery voltage is a build parameter (platformio.ini or CMake definition)
 - SoftwareSerial libray is useable for debugging or send serial data (9600bps) on PB0
+- Double trigger for 'off' signal is a build parameter. It allows to clap one time for `on` and two times for `off`. The delay between two triggers is 1 second.
+- Detail of on/off signals are build parameters (using [RC-Switch](https://github.com/sui77/rc-switch) `Type C Intertechno`)
 
 Sample output trace:
 ```
 REMOTESIMULATOR
-GIT: bc098ad88e773c9947c5373d6485fa0f6edf0c7ed
+GIT: 9b555aba0e02795dadab3060a91e6916c52096a9
 SWITCH_FAMILY: a
 SWITCH_GROUP: 1
 SWITCH_NUMBER: 1
-Current Voltage:5560mV
-Emit signal
+LOW BATTERY VOLTAGE: 2300
+USE DOUBLE TRIGGER FOR OFF: 1
+Current Voltage:5339mV
+Wake up
 [...]
 ```
 
@@ -44,7 +46,7 @@ The main source code has been slightly adapted from a version found on [Onlinux.
 
 # Compile the code
 
-The code can be compiled a plain AVR gcc toolchain, using the script in `tools/scripts`. 
+The code can be compiled a plain AVR gcc toolchain, using the script in `tools/scripts`. Note that these script will use parameters which may not be suitable for all usages.
 It also can be compiled using the [PlatformIO](https://platformio.org) tool.
 
 ## Using CMake
@@ -60,6 +62,5 @@ Once installed, type `pip3 install platformio`, then `pio run`.
 We rely on other open source projects, which are:
 * [CMake](https://cmake.org/)
 * [CMake for AVR library](https://github.com/mkleemann/cmake-avr)
-* [Arduino Core](https://github.com/arduino/ArduinoCore-avr)
-* [ATTiny Arduino support](https://github.com/damellis/attiny)
+* [ATTiny Arduino Core from Spence Konde](https://github.com/SpenceKonde/ATTinyCore)
 * [RC-Switch Arduino library](https://github.com/sui77/rc-switch)

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,5 +21,7 @@ upload_speed = 230400
 build_flags =
   -DSWITCH_FAMILY='a'
   -DSWITCH_GROUP=1
+  -DUSE_DOUBLE_TRIGGER_FOR_OFF=1
   -DSWITCH_NUMBER=1
+  -DLOW_BATTERY_VOLTAGE=2300
   !python git_rev_macro.py

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@
 #include <avr/power.h>
 #include <avr/sleep.h>
 #include <avr/wdt.h>
-#include <util/delay.h>
 
 #include <RCSwitch.h>
 #include <TinySoftwareSerial.h>
@@ -54,11 +53,11 @@
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
-#define AT __FILE__ ":" TOSTRING(__LINE__)
 
-// Led will flash if battery level is lower than this value
-// in mV.
-#define LOW_BATTERY_LEVEL (2 * 1150)
+#ifdef USE_DOUBLE_TRIGGER_FOR_OFF
+bool f_is_first_trigger = true;
+volatile bool f_second_trigger_overtime = false;
+#endif
 
 // How many watchdog interrupt before battery sensing
 #define WDT_COUNT_BEFORE_CURRENT_SENSING (3600 / 8)
@@ -84,9 +83,9 @@ void blink(int blinkCount) {
   pinMode(LED_PIN, OUTPUT);
   for (byte i = blinkCount; i > 0; i--) {
     digitalWrite(LED_PIN, HIGH);
-    _delay_ms(100);
+    delayMicroseconds(100000);
     digitalWrite(LED_PIN, LOW);
-    _delay_ms(100);
+    delayMicroseconds(100000);
   }
 
   pinMode(LED_PIN, INPUT); // reduce power
@@ -95,7 +94,7 @@ void blink(int blinkCount) {
 void lowBatteryWarning() {
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, HIGH);
-  _delay_ms(10);
+  delayMicroseconds(10000);
 
   pinMode(LED_PIN, INPUT);
 }
@@ -109,22 +108,20 @@ uint16_t readVcc(void) {
   sbi(ADMUX, MUX3);
   sbi(ADMUX, MUX2);
   sbi(ADCSRA, ADEN);
-  _delay_ms(2);
+  delayMicroseconds(2000);
 
   uint16_t accumulator = 0;
 
   // we will discard 10 first reads,
   // then mean 16 reads
-  for (uint8_t i = (10 + 16); i > 0; --i) {
+  for (uint8_t i = 0; i < (10 + 16); ++i) {
     sbi(ADCSRA, ADSC);
     while (bit_is_set(ADCSRA, ADSC)) {}
-
-    if (i >= 10) {
+    if (i > 9) {
       accumulator += ADC;
     }
   }
-  // >> 4 is /16
-  result = (accumulator >> 4);
+  result = (accumulator / 16);
 
   // Back-calculate AVcc in mV
   uint16_t millivolts = ((uint32_t)1024 * REF_1V1) / result;
@@ -165,8 +162,15 @@ void system_sleep() {
   sleep_disable();
 }
 
-void setup_watchdog() {
+void setup_watchdog1s() {
   wdt_reset();
+  WDTCR = 0;
+  WDTCR |= (1 << WDE) | (1 << WDIE) | (1 << WDP2) | (1 << WDP1); // 1s timeout
+}
+
+void setup_watchdog8s() {
+  wdt_reset();
+  WDTCR = 0;
   WDTCR |= (1 << WDE) | (1 << WDIE) | (1 << WDP3) | (1 << WDP0); // 8s timeout
 }
 
@@ -177,6 +181,9 @@ ISR(WDT_vect) {
     current_wdt_count = 0;
   }
   current_wdt_count++;
+#ifdef USE_DOUBLE_TRIGGER_FOR_OFF
+  f_second_trigger_overtime = true;
+#endif
 }
 
 ISR(BADISR_vect) { blink(20); }
@@ -197,52 +204,68 @@ ISR(INT0_vect) {
 }
 #endif
 
-void setup() {
-
-  pinMode(TX_PIN, OUTPUT);
-  pinMode(WAKEUP_PIN, INPUT);
-  mySwitch.enableTransmit(TX_PIN);
-
-  // power_timer0_enable();
-  power_timer0_disable();
-
-  // power_timer1_enable();
-  power_timer1_disable();
-
-  // power_usi_enable();
-  power_usi_disable();
-
-  // UART support, TX only
-  // see
-  // https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/extras/ATtiny_x5.md
-  Serial.begin(9600);
-  ACSR &= ~(1 << ACIE);
-  ACSR |= ~(1 << ACD);
-
+void printConfigurationInformations() {
   Serial.println("REMOTESIMULATOR");
   Serial.print("GIT: ");
   Serial.println(TOSTRING(GIT_TAG));
-
   Serial.print("SWITCH_FAMILY: ");
   Serial.println(*TOSTRING(SWITCH_FAMILY));
   Serial.print("SWITCH_GROUP: ");
   Serial.println(SWITCH_GROUP);
   Serial.print("SWITCH_NUMBER: ");
   Serial.println(SWITCH_NUMBER);
+  Serial.print("LOW BATTERY VOLTAGE: ");
+  Serial.println(LOW_BATTERY_VOLTAGE);
+  Serial.print("USE DOUBLE TRIGGER FOR OFF: ");
+  Serial.println(*TOSTRING(USE_DOUBLE_TRIGGER_FOR_OFF));
+  delayMicroseconds(100000);
+}
 
-  _delay_ms(100);
+void setup() {
+  setup_watchdog8s();
+
+  pinMode(TX_PIN, OUTPUT);
+  pinMode(WAKEUP_PIN, INPUT);
+  mySwitch.enableTransmit(TX_PIN);
+
+  // power_timer0_disable();
+  // power_timer1_disable();
+  // power_usi_disable();
+
+  // UART support, TX only. See
+  // https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/extras/ATtiny_x5.md
+  Serial.begin(9600);
+  ACSR &= ~(1 << ACIE);
+  ACSR |= ~(1 << ACD);
+
+  printConfigurationInformations();
 
   lowBattery =
-      !(readVcc() >= LOW_BATTERY_LEVEL); // Initialize battery level value
+      !(readVcc() >= LOW_BATTERY_VOLTAGE); // Initialize battery level value
 
   blink(2);
-  setup_watchdog();
+}
+
+void EmitOnCommand() {
+  Serial.println("Emit On");
+  blink(1);
+  mySwitch.switchOn(*TOSTRING(SWITCH_FAMILY), SWITCH_GROUP, SWITCH_NUMBER);
+  delayMicroseconds(10000);
+}
+
+void EmitOffCommand() {
+  Serial.println("Emit off");
+  blink(2);
+  mySwitch.switchOff(*TOSTRING(SWITCH_FAMILY), SWITCH_GROUP, SWITCH_NUMBER);
+  delayMicroseconds(10000);
 }
 
 /*!
  * If USE_HIGH_PCINT1, ensure PB3 is high otherwise do not trigger any action
  */
 void loop() {
+
+  wdt_reset();
 
   if (lowBattery) {
     // Flash for 1ms every 8s
@@ -251,19 +274,51 @@ void loop() {
     Serial.println("Low battery");
   }
 
+#ifdef USE_DOUBLE_TRIGGER_FOR_OFF
+
+  // 1s watchdog timed out before a second
+  // trigger occurs, send a "ON" command
+  if (!f_is_first_trigger && f_second_trigger_overtime) {
+    Serial.println("overtime");
+    setup_watchdog8s();
+    f_is_first_trigger = true;
+    f_second_trigger_overtime = false;
+    EmitOnCommand();
+  }
+
+#endif
+
   if (f_int) {
-    Serial.println("Emit signal");
     f_int = false;
-    blink(1);
-    mySwitch.switchOn(*TOSTRING(SWITCH_FAMILY), SWITCH_GROUP, SWITCH_NUMBER);
-    _delay_ms(100);
+
+#ifdef USE_DOUBLE_TRIGGER_FOR_OFF
+
+    if (f_is_first_trigger) {
+      Serial.println("First trigger");
+      setup_watchdog1s();
+      delay(100);
+      f_is_first_trigger = false;
+    } else {
+      Serial.println("Second trigger");
+      setup_watchdog8s();
+      f_is_first_trigger = true;
+      f_second_trigger_overtime = false;
+      EmitOffCommand();
+    }
+#else
+    EmitOnCommand();
+    setup_watchdog8s();
+#endif
 
   } else if (f_wdt) {
     Serial.println("Current sensing");
-    lowBattery = (readVcc() <= LOW_BATTERY_LEVEL);
+    lowBattery = (readVcc() <= LOW_BATTERY_VOLTAGE);
     f_wdt = false;
+
+  } else {
+    setup_watchdog8s();
   }
-  setup_watchdog();
+
   arm_interrupt();
   system_sleep();
   Serial.println("Wake up");

--- a/tools/cmake/avr.cmake
+++ b/tools/cmake/avr.cmake
@@ -116,9 +116,11 @@ include_directories(${RC_SWITCH})
 add_avr_library(rc-switch STATIC "${RC_SWITCH}/RCSwitch.cpp")
 avr_target_link_libraries(rc-switch arduino)
 
-message(STATUS "Zibase(c) signal family: ${SWITCH_FAMILY}" )
-message(STATUS "Zibase(c) signal group:  ${SWITCH_GROUP}"  )
-message(STATUS "Zibase(c) signal number: ${SWITCH_NUMBER}" )
+message(STATUS "Zibase(c) signal family    : ${SWITCH_FAMILY}"      )
+message(STATUS "Zibase(c) signal group     : ${SWITCH_GROUP}"       )
+message(STATUS "Zibase(c) signal number    : ${SWITCH_NUMBER}"      )
+message(STATUS "Low battery voltage        : ${LOW_BATTERY_VOLTAGE}")
+message(STATUS "Use double trigger for off : ${USE_DOUBLE_TRIGGER_FOR_OFF}")
 
 add_avr_executable(${PROJECT_NAME} "${CMAKE_SOURCE_DIR}/src/main.cpp")
 
@@ -126,7 +128,15 @@ add_definitions(
   -DSWITCH_FAMILY='${SWITCH_FAMILY}' 
   -DSWITCH_GROUP=${SWITCH_GROUP} 
   -DSWITCH_NUMBER=${SWITCH_NUMBER}
-  -DGIT_TAG=${GIT_TAG})
+  -DGIT_TAG=${GIT_TAG}
+  -DLOW_BATTERY_VOLTAGE=${LOW_BATTERY_VOLTAGE}
+  )
+
+if(USE_DOUBLE_TRIGGER_FOR_OFF)
+add_definitions(
+  -DUSE_DOUBLE_TRIGGER_FOR_OFF=y
+)
+endif()
 
 avr_target_link_libraries(${PROJECT_NAME} arduino)
 avr_target_link_libraries(${PROJECT_NAME} rc-switch)

--- a/tools/scripts/init-avr-linux.sh
+++ b/tools/scripts/init-avr-linux.sh
@@ -25,10 +25,12 @@ cmake  $1 \
 -G "Unix Makefiles" \
 -DMCU_SPEED=$CLOCK \
 -DAVR_MCU=$MCU \
+-DLOW_BATTERY_VOLTAGE=2300 \
 -DBOARD_VARIANT=$BOARD \
 -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_TOOLCHAIN_FILE=$1/third_party/cmake-avr/generic-gcc-avr.cmake \
 -DGIT_TAG=`python git_rev_macro.py` \
 -DSWITCH_FAMILY='a' \
 -DSWITCH_GROUP=1 \
+-DUSE_DOUBLE_TRIGGER_FOR_OFF:BOOL=TRUE \
 -DSWITCH_NUMBER=1

--- a/tools/scripts/init-avr-windows.bat
+++ b/tools/scripts/init-avr-windows.bat
@@ -39,6 +39,7 @@ cmake  %1                                                              ^
 -DCMAKE_TOOLCHAIN_FILE:PATH=%1/third_party/cmake-avr/generic-gcc-avr.cmake ^
 -G "Unix Makefiles"                                                    ^
 -DMCU_SPEED:STRING=%CLOCK%                                             ^
+-DLOW_BATTERY_VOLTAGE=2300                                             ^
 -DAVR_MCU:STRING=%MCU%                                                 ^
 -DBOARD_VARIANT:STRING=%BOARD%                                         ^
 -DCMAKE_BUILD_TYPE=Release                                             ^
@@ -48,4 +49,5 @@ cmake  %1                                                              ^
 -DSWITCH_FAMILY='a'                                                    ^
 -DSWITCH_GROUP=1                                                       ^
 -DSWITCH_NUMBER=1                                                      ^
+-DUSE_DOUBLE_TRIGGER_FOR_OFF:BOOL=TRUE                                 ^
 -DGIT_TAG= %%a


### PR DESCRIPTION
Useful with the sound detector, this feature allow to clap one time for `on` signal, and two times for `off` signal.
The feature can be activated using a compilation switch, using Platformio or CMake options.